### PR TITLE
when searching a list of entities and pressing the Go button, initial…

### DIFF
--- a/src/menu/ACommonSubSection.ts
+++ b/src/menu/ACommonSubSection.ts
@@ -165,10 +165,6 @@ export abstract class ACommonSubSection implements IStartMenuSubSection {
         search: {
           ids: searchField.value,
           type: this.dataSource.tableName
-        },
-        subType: {
-          key: SPECIES_SESSION_KEY,
-          value: getSelectedSpecies()
         }
       }, this.getDefaultSessionValues());
     });

--- a/src/views/ACommonList.ts
+++ b/src/views/ACommonList.ts
@@ -5,6 +5,7 @@
 import {AStartList, IAStartListOptions} from 'tdp_core/src/views/AStartList';
 import {ISelection, IViewContext} from 'tdp_core/src/views';
 import {getTDPDesc, getTDPFilteredRows, IParams} from 'tdp_core/src/rest';
+import {getSelectedSpecies, SPECIES_SESSION_KEY} from '../common';
 
 export interface ICommonDBConfig {
   idType: string;
@@ -31,7 +32,11 @@ export abstract class ACommonList extends AStartList {
     super(context, selection, parent, Object.assign({
       additionalScoreParameter: dataSource,
       itemName: dataSource.name,
-      itemIDType: dataSource.idType
+      itemIDType: dataSource.idType,
+      subType: {
+        key: SPECIES_SESSION_KEY,
+        value: getSelectedSpecies()
+      }
     }, options));
 
     if(!this.namedSet) {


### PR DESCRIPTION
…ize the new view with the correct species

Solves the following problem:
- search some entities in the StartMenu
- click "Go"
- save current RankingView as NamedSet
- the new NamedSet is available in every species