### PR TITLE
Fix species start menu

### DIFF
--- a/src/menu/ACommonSubSection.ts
+++ b/src/menu/ACommonSubSection.ts
@@ -57,7 +57,7 @@ export abstract class ACommonSubSection implements IStartMenuSubSection {
   }
 
   update() {
-    this.data.update(true);
+    this.data.update();
   }
 
   push(namedSet: INamedSet) {


### PR DESCRIPTION
Create `All` named set for all species (e.g. mouse)
closes Caleydo/tdp_bi_bioinfodb#703