### PR TITLE
Fix selected tab on welcome page

### DIFF
--- a/src/menu/SpeciesSelectorMenuSection.ts
+++ b/src/menu/SpeciesSelectorMenuSection.ts
@@ -114,7 +114,7 @@ export default class SpeciesSelectorMenuSection implements IStartMenuSection {
       .on('click', function(d) {
         (<Event>d3event).preventDefault();
         session.store(tabSessionKey, d.id);
-        $(this).tab('show');
+        $(this).tab('show').blur();
       }).each(function(this: HTMLElement, d) {
         if (d.id === session.retrieve(tabSessionKey, defaultTabSessionValue)) {
           this.click();


### PR DESCRIPTION
Fixes Caleydo/tdp_bi_bioinfodb#717

![ordino-tab-welcome-page](https://user-images.githubusercontent.com/5851088/35512609-a8e2e310-0500-11e8-9c31-635f711c4832.gif)
