### PR TITLE
Set jQuery object to `any` to fix sortable typing

### DIFF
--- a/src/views/AOncoPrint.ts
+++ b/src/views/AOncoPrint.ts
@@ -349,7 +349,7 @@ export abstract class AOncoPrint extends AView {
     $ids.exit().remove().each(() => this.setBusy(false));
 
     //sortable
-    $(this.$table.node()) // jquery
+    (<any>$(this.$table.node())) // jquery
       .sortable({
         handle: 'th.geneLabel',
         axis: 'y',


### PR DESCRIPTION
Fixes #106 

### Summary

* Set jQuery object to `any` to fix sortable typing
* We need to use `any` as there are no typings for jQuery UI available

The CircleCI build of ordino_product is successful when using this branch (see https://circleci.com/gh/Caleydo/ordino_product/975)