### PR TITLE
Remove the unknown category

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,15 +11,15 @@ export const copyNumberCat = [
   {value: 0, name: 'NORMAL', color: '#dcdcdc', border: 'transparent'},
   //{value: 1, name: 'Low level amplification', color: '#f4a582'},
   //{value: 2, name: 'High level amplification', color: '#ca0020'},
-  {value: 'null', name: 'Unknown', color: '#FCFCFC', border: '#dcdcdc'}
+  // {value: 'null', name: 'Unknown', color: '#FCFCFC', border: '#dcdcdc'}
 ];
-export const unknownCopyNumberValue: any = copyNumberCat[copyNumberCat.length-1].value;
+export const unknownCopyNumberValue: any = 'null';
 
 export const mutationCat = [
   {value: 'true', name: 'Mutated', color: '#1BA64E', border: 'transparent'},
   {value: 'false', name: 'Non Mutated', color: '#aaa', border: 'transparent'},
-  {value: 'null', name: 'Unknown', color: 'transparent', border: '#999'}
+  // {value: 'null', name: 'Unknown', color: 'transparent', border: '#999'}
 ];
-export const unknownMutationValue: any = mutationCat[mutationCat.length-1].value;
+export const unknownMutationValue: any = 'null';
 
 export const GENE_IDTYPE = 'Ensembl';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,15 +11,15 @@ export const copyNumberCat = [
   {value: 0, name: 'NORMAL', color: '#dcdcdc', border: 'transparent'},
   //{value: 1, name: 'Low level amplification', color: '#f4a582'},
   //{value: 2, name: 'High level amplification', color: '#ca0020'},
-  // {value: 'null', name: 'Unknown', color: '#FCFCFC', border: '#dcdcdc'}
+  //{value: 'null', name: 'Unknown', color: '#FCFCFC', border: '#dcdcdc'}
 ];
-export const unknownCopyNumberValue: any = 'null';
+export const unknownCopyNumberValue: any = NaN;
 
 export const mutationCat = [
   {value: 'true', name: 'Mutated', color: '#1BA64E', border: 'transparent'},
   {value: 'false', name: 'Non Mutated', color: '#aaa', border: 'transparent'},
   // {value: 'null', name: 'Unknown', color: 'transparent', border: '#999'}
 ];
-export const unknownMutationValue: any = 'null';
+export const unknownMutationValue: any = NaN;
 
 export const GENE_IDTYPE = 'Ensembl';

--- a/src/styles/_onco_print.scss
+++ b/src/styles/_onco_print.scss
@@ -17,7 +17,7 @@ $oncoprint_cnv_normal: '0';
 $oncoprint_cnv_normal_color: #dcdcdc;
 $oncoprint_cnv_normal_border: transparent;
 
-$oncoprint_cnv_unknown: 'null';
+$oncoprint_cnv_unknown: 'NaN';
 $oncoprint_cnv_unknown_color: #FCFCFC;
 $oncoprint_cnv_unknown_border: #dcdcdc;
 
@@ -27,7 +27,7 @@ $oncoprint_mut_mutated_border: transparent;
 $oncoprint_mut_not_mutated: 'false';
 $oncoprint_mut_not_mutated_color: #aaa;
 $oncoprint_mut_not_mutated_border: transparent;
-$oncoprint_mut_unknown: 'null';
+$oncoprint_mut_unknown: 'NaN';
 $oncoprint_mut_unknown_color: transparent;
 $oncoprint_mut_unknown_border: #999;
 

--- a/src/views/AOncoPrint.ts
+++ b/src/views/AOncoPrint.ts
@@ -248,7 +248,7 @@ export abstract class AOncoPrint extends AView {
       $mutLegend.append('li').attr('data-mut', d.value).text(d.name);
     });
       // append the legen for missing values
-    $mutLegend.append('li').attr('data-mut',unknownMutationValue ).text('Missing Values');
+    $mutLegend.append('li').attr('data-mut', unknownMutationValue ).text('Missing Values');
 
     $node.append('div').attr('class', 'alert alert-info alert-dismissible').attr('role', 'alert').html(`
       <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>

--- a/src/views/AOncoPrint.ts
+++ b/src/views/AOncoPrint.ts
@@ -238,7 +238,7 @@ export abstract class AOncoPrint extends AView {
     copyNumberCat.forEach((d) => {
       $cnLegend.append('li').attr('data-cnv', d.value).text(d.name);
     });
-    // append the legen for missing values
+    // append the legend for missing values
     $cnLegend.append('li').attr('data-cnv', unknownCopyNumberValue).text('Missing Values');
 
     const $mutLegend = $legend.append('ul');
@@ -247,7 +247,7 @@ export abstract class AOncoPrint extends AView {
     mutationCat.forEach((d) => {
       $mutLegend.append('li').attr('data-mut', d.value).text(d.name);
     });
-      // append the legen for missing values
+      // append the legend for missing values
     $mutLegend.append('li').attr('data-mut', unknownMutationValue ).text('Missing Values');
 
     $node.append('div').attr('class', 'alert alert-info alert-dismissible').attr('role', 'alert').html(`

--- a/src/views/AOncoPrint.ts
+++ b/src/views/AOncoPrint.ts
@@ -238,6 +238,8 @@ export abstract class AOncoPrint extends AView {
     copyNumberCat.forEach((d) => {
       $cnLegend.append('li').attr('data-cnv', d.value).text(d.name);
     });
+    // append the legen for missing values
+    $cnLegend.append('li').attr('data-cnv', unknownCopyNumberValue).text('Missing Values');
 
     const $mutLegend = $legend.append('ul');
     $mutLegend.append('li').classed('title', true).text('Mutation');
@@ -245,6 +247,8 @@ export abstract class AOncoPrint extends AView {
     mutationCat.forEach((d) => {
       $mutLegend.append('li').attr('data-mut', d.value).text(d.name);
     });
+      // append the legen for missing values
+    $mutLegend.append('li').attr('data-mut',unknownMutationValue ).text('Missing Values');
 
     $node.append('div').attr('class', 'alert alert-info alert-dismissible').attr('role', 'alert').html(`
       <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>


### PR DESCRIPTION
Closes Caleydo/tdp_publicdb#99

### Summary

* Commented out the category `unknown` that represents the missing values.

### Documentation
We assign the value `'null'`(type string) to the missing rows. For the purpose of this ticket it is not necessary removing the `missingCategory` property in the config.ts in tdp_publicdb.
https://github.com/Caleydo/tdp_publicdb/blob/d8b3eceb66391f49dded9753434b79e64a610d2c/src/config.ts#L341-L349

#### Regarding the compatibility of older session: 

The issue is that the the unknown values will not be filtered anymore since the category unknown does not exist anymore.
The filter can be one of the 3 below combinations:
* `['null'] ` --> filter everything but the unknown values
* `['true', 'null']`--> filter out values that are false(NonMutated)
* `['true", 'false']` --> filter out missing values

For each case we would like to set the correct filter when an older graph gets imported and to achieve that we would have to translate the filters to work with this implementation.

For the first two filters it would be possible to set the correct filter but for the third the filter would be hard to translate since the unknown category is missing and the filter filters out that category.

![unkown_category](https://user-images.githubusercontent.com/51322092/82207888-d9249f00-990a-11ea-886c-51811b180a9f.png)