### PR TITLE
Switch to `jstat` package (instead of `jStat`) and update to newest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "jest-raw-loader": "1.0.1"
   },
   "dependencies": {
-    "jStat": "1.8.6",
+    "jstat": "^1.9.3",
     "jquery-ui": "1.12.1",
     "tdp_core": "github:datavisyn/tdp_core#develop"
   },

--- a/src/views/ACoExpression.ts
+++ b/src/views/ACoExpression.ts
@@ -10,7 +10,7 @@ import {Range} from 'phovea_core/src/range';
 import {toSelectOperation, SelectOperation, integrateSelection} from 'phovea_core/src/idtype';
 import {AD3View} from 'tdp_core/src/views/AD3View';
 import {integrateColors, colorScale, legend} from './utils';
-import {jStat} from 'jStat';
+import {jStat} from 'jstat';
 
 const FORM_ID_REFERENCE_GENE = 'referenceGene';
 

--- a/src/views/AExpressionVsCopyNumber.ts
+++ b/src/views/AExpressionVsCopyNumber.ts
@@ -12,7 +12,7 @@ import {FormElementType, IFormSelectDesc} from 'tdp_core/src/form';
 import {resolveId} from 'tdp_core/src/views';
 import {AD3View} from 'tdp_core/src/views/AD3View';
 import {colorScale, integrateColors, legend} from './utils';
-import {jStat} from 'jStat';
+import {jStat} from 'jstat';
 
 const spearmancoeffTitle = 'Spearman Coefficient: ';
 


### PR DESCRIPTION
Closes Caleydo/tdp_gene#133

### Summary 
* Tested the components where the library is used by logging the results. The results of the calculations where the same.
* Updated imports accordingly.
