### PR TITLE
Remove select2 placeholder CSS

### DIFF
--- a/src/styles/_startMenu.scss
+++ b/src/styles/_startMenu.scss
@@ -128,16 +128,6 @@
         form {
           width: 80%;
         }
-
-        // fix select2 placeholder cutoff
-        // https://github.com/select2/select2/issues/291
-        .select2-search__field {
-          width: auto !important;
-        }
-
-        .select2-selection__rendered > li:first-child > .select2-search__field {
-          width: 30em !important;
-        }
       }
     }
   }


### PR DESCRIPTION
### Summary

Removes some CSS code for the select2 in the start menu. We can due this as we have a more general solution with PR datavisyn/tdp_core#381.


![grafik](https://user-images.githubusercontent.com/5851088/85271812-97dc5d80-b47b-11ea-8e45-7af7f9ca9a23.png)

![grafik](https://user-images.githubusercontent.com/5851088/85271859-ac205a80-b47b-11ea-921b-e6cc912c9e2d.png)
