### PR TITLE
Skip non-string values in GeneIDTypeDetector

### DIFF
--- a/src/GeneIDTypeDetector.ts
+++ b/src/GeneIDTypeDetector.ts
@@ -1,3 +1,11 @@
+/**
+ * Detect items from a data array starting `ENS` or `LRG`.
+ * Returns a number between 0 and 1 defining the fraction of matching genes in the array.
+ *
+ * @param data Data array with objects or strings
+ * @param accessor Accessor function to retrieve a certain field from a data item
+ * @param sampleSize Number of samples to test; can be used to limit iterations for large arrays
+ */
 function detectIDType(data: any[], accessor: (row: any) => string, sampleSize: number): number {
   const testSize = Math.min(data.length, sampleSize);
   if (testSize <= 0) {
@@ -10,7 +18,7 @@ function detectIDType(data: any[], accessor: (row: any) => string, sampleSize: n
   for(let i = 0; i < testSize; ++i) {
     const v = accessor(data[i]);
 
-    if (v == null || v.trim().length === 0) {
+    if (v == null || typeof(v) !== 'string' || v.trim().length === 0) {
       continue; //skip empty samples
     }
 

--- a/tests/GeneIDTypeDetector.test.ts
+++ b/tests/GeneIDTypeDetector.test.ts
@@ -1,0 +1,49 @@
+import {geneIDTypeDetector} from '../src/GeneIDTypeDetector';
+
+describe('GeneIDTypeDetector', () => {
+  const accessor: (row: any) => string = (row: any) => row.toString();
+  const sampleSize = 10; // greater than data array length
+
+  it('string array', () => {
+    const data = ['foo', 'bar'];
+    expect(geneIDTypeDetector().detectIDType(data, accessor, sampleSize)).toEqual(0);
+  });
+
+  it('boolean array', () => {
+    const data = [true, false];
+    expect(geneIDTypeDetector().detectIDType(data, accessor, sampleSize)).toEqual(0);
+  });
+
+  it('number array', () => {
+    const data = [1, 2];
+    expect(geneIDTypeDetector().detectIDType(data, accessor, sampleSize)).toEqual(0);
+  });
+
+  it('All Ensembl IDs', () => {
+    const data = ['ENSG0000123', 'ENSG0000234'];
+    expect(geneIDTypeDetector().detectIDType(data, accessor, sampleSize)).toEqual(1);
+  });
+
+  it('Half Ensembl IDs', () => {
+    const data = ['ENSG0000123', 'ENSG0000234', 'foo', 'bar'];
+    expect(geneIDTypeDetector().detectIDType(data, accessor, sampleSize)).toEqual(0.5);
+  });
+
+  it('Strings not starting with ENS or LRG', () => {
+    const data = ['fooENSG', 'barENSG'];
+    expect(geneIDTypeDetector().detectIDType(data, accessor, sampleSize)).toEqual(0);
+  });
+
+  it('Sample size smaller than data length', () => {
+    const data = ['ENSG0000123', 'ENSG0000234', 'foo', 'bar'];
+    const sampleSize = 2;
+    expect(geneIDTypeDetector().detectIDType(data, accessor, sampleSize)).toEqual(1); // 0 because only the first two items will be checked they are EnsemblIDs
+  });
+
+  it('Detect items from the beginning', () => {
+    const data = ['foo', 'bar', 'ENSG0000123', 'ENSG0000234'];
+    const sampleSize = 2;
+    expect(geneIDTypeDetector().detectIDType(data, accessor, sampleSize)).toEqual(0); // 0 because only the first two items will be checked they are not EnsemblIDs
+  });
+
+});


### PR DESCRIPTION
Fixes #136

### Summary

Check only string values and skip all other variable types.