### PR TITLE
Remove select2 placeholder CSS

### DIFF
--- a/dist/scss/_startMenu.scss
+++ b/dist/scss/_startMenu.scss
@@ -128,16 +128,6 @@
         form {
           width: 80%;
         }
-
-        // fix select2 placeholder cutoff
-        // https://github.com/select2/select2/issues/291
-        .select2-search__field {
-          width: auto !important;
-        }
-
-        .select2-selection__rendered > li:first-child > .select2-search__field {
-          width: 30em !important;
-        }
       }
     }
   }

--- a/src/scss/_startMenu.scss
+++ b/src/scss/_startMenu.scss
@@ -128,16 +128,6 @@
         form {
           width: 80%;
         }
-
-        // fix select2 placeholder cutoff
-        // https://github.com/select2/select2/issues/291
-        .select2-search__field {
-          width: auto !important;
-        }
-
-        .select2-selection__rendered > li:first-child > .select2-search__field {
-          width: 30em !important;
-        }
       }
     }
   }


### PR DESCRIPTION
Part of Caleydo/tdp_bi_bioinfodb#1138

### Summary 
* As it seems the same way the equivalent tdp_core counterpart was not present in the develop branch, the changes from https://github.com/Caleydo/tdp_gene/pull/135 have also been undone.

### Screenshot

![select2_placeholder](https://user-images.githubusercontent.com/51322092/93882617-beab6980-fce0-11ea-9459-98e85db1fd16.gif)
