### PR TITLE
Add SVG axis style again

### DIFF
--- a/dist/scss/_expression_vs_copynumber.scss
+++ b/dist/scss/_expression_vs_copynumber.scss
@@ -6,14 +6,12 @@
       font-weight: 500;
   }
 
-  svg {
-    .axis path,
-    .axis line {
-      fill: none;
-      stroke-width: 1;
-      stroke: black;
-      shape-rendering: crispEdges;
-    }
+  .axis path,
+  .axis line {
+    fill: none;
+    stroke-width: 1;
+    stroke: $core_color_almost_black;
+    shape-rendering: crispEdges;
   }
 
   .mark {

--- a/dist/scss/_expression_vs_copynumber.scss
+++ b/dist/scss/_expression_vs_copynumber.scss
@@ -6,6 +6,16 @@
       font-weight: 500;
   }
 
+  svg {
+    .axis path,
+    .axis line {
+      fill: none;
+      stroke-width: 1;
+      stroke: black;
+      shape-rendering: crispEdges;
+    }
+  }
+
   .mark {
     fill: $core_color_almost_black;
     fill-opacity: 0.8;

--- a/src/scss/_expression_vs_copynumber.scss
+++ b/src/scss/_expression_vs_copynumber.scss
@@ -6,14 +6,12 @@
       font-weight: 500;
   }
 
-  svg {
-    .axis path,
-    .axis line {
-      fill: none;
-      stroke-width: 1;
-      stroke: black;
-      shape-rendering: crispEdges;
-    }
+  .axis path,
+  .axis line {
+    fill: none;
+    stroke-width: 1;
+    stroke: $core_color_almost_black;
+    shape-rendering: crispEdges;
   }
 
   .mark {

--- a/src/scss/_expression_vs_copynumber.scss
+++ b/src/scss/_expression_vs_copynumber.scss
@@ -6,6 +6,16 @@
       font-weight: 500;
   }
 
+  svg {
+    .axis path,
+    .axis line {
+      fill: none;
+      stroke-width: 1;
+      stroke: black;
+      shape-rendering: crispEdges;
+    }
+  }
+
   .mark {
     fill: $core_color_almost_black;
     fill-opacity: 0.8;


### PR DESCRIPTION
### Summary

PR https://github.com/datavisyn/tdp_core/pull/455 removes the axis styles from tdp_core, which causes broken axis in the Co-Expression and Expression vs. Copy Number scatterplot. Adding the styles here again fixes the both plots.

![grafik](https://user-images.githubusercontent.com/5851088/102633671-05c6c080-4151-11eb-932e-28cf26980b8d.png)
